### PR TITLE
Simulation serialization & Initial snapshot report

### DIFF
--- a/backend/.eslintrc.js
+++ b/backend/.eslintrc.js
@@ -30,5 +30,6 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
+    '@typescript-eslint/no-empty-interface': 'off',
   },
 };

--- a/backend/package.json
+++ b/backend/package.json
@@ -24,6 +24,7 @@
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-ping": "^1.4.0",
+    "lodash": "^4.17.20",
     "socket.io": "^2.3.0",
     "swagger-ui-express": "^4.1.4",
     "tsoa": "^3.3.0"
@@ -31,6 +32,7 @@
   "devDependencies": {
     "@types/body-parser": "^1.19.0",
     "@types/express": "^4.17.8",
+    "@types/lodash": "^4.14.165",
     "@types/node": "^14.11.8",
     "@types/socket.io": "^2.1.11",
     "@types/swagger-ui-express": "^4.1.2",

--- a/backend/src/core/SimulationNamespaceListener.ts
+++ b/backend/src/core/SimulationNamespaceListener.ts
@@ -6,6 +6,7 @@ import { socketEvents } from '../common/constants/socketEvents';
 import { getClientCount } from '../utils/getClientCount';
 import { emitWelcome } from '../utils/emitWelcome';
 import { SimulationDeleteNodePayload } from '../common/socketPayloads/SimulationDeleteNodePayload';
+import { SimulationRequestSnapshotPayload } from '../common/socketPayloads/SimulationRequestStatePayload';
 
 export class SimulationNamespaceListener {
   private readonly simulationUid: string;
@@ -41,6 +42,10 @@ export class SimulationNamespaceListener {
     socket.on(
       socketEvents.simulation.deleteNode,
       this.handleSimulationDeleteNode
+    );
+    socket.on(
+      socketEvents.simulation.requestSnapshot,
+      this.handleSimulationRequestSnapshot
     );
   };
 
@@ -78,5 +83,11 @@ export class SimulationNamespaceListener {
     body: SimulationDeleteNodePayload
   ) => {
     simulationBridge.handleSimulationDeleteNode(this.simulationUid, body);
+  };
+
+  private readonly handleSimulationRequestSnapshot = (
+    body: SimulationRequestSnapshotPayload
+  ) => {
+    simulationBridge.handleSimulationRequestSnapshot(this.simulationUid, body);
   };
 }

--- a/backend/src/core/SimulationNode.ts
+++ b/backend/src/core/SimulationNode.ts
@@ -1,7 +1,9 @@
+import { SimulationNodeSnapshot } from '../common/SimulationNodeSnapshot';
+
 export class SimulationNode {
-  public nodeUid: string;
-  public positionX: number;
-  public positionY: number;
+  public readonly nodeUid: string;
+  public readonly positionX: number;
+  public readonly positionY: number;
 
   constructor(nodeUid: string, positionX: number, positionY: number) {
     this.nodeUid = nodeUid;
@@ -11,5 +13,13 @@ export class SimulationNode {
 
   public readonly teardown = (): void => {
     // no-op for now
+  };
+
+  public readonly takeSnapshot = (): SimulationNodeSnapshot => {
+    return {
+      nodeUid: this.nodeUid,
+      positionX: this.positionX,
+      positionY: this.positionY,
+    };
   };
 }

--- a/backend/src/core/simulationBridge.ts
+++ b/backend/src/core/simulationBridge.ts
@@ -9,6 +9,8 @@ import { SimulationPingPayload } from '../common/socketPayloads/SimulationPingPa
 import { SimulationNamespaceListener } from './SimulationNamespaceListener';
 import { SimulationDeleteNodePayload } from '../common/socketPayloads/SimulationDeleteNodePayload';
 import { SimulationNodeDeletedPayload } from '../common/socketPayloads/SimulationNodeDeletedPayload';
+import { SimulationRequestSnapshotPayload } from '../common/socketPayloads/SimulationRequestStatePayload';
+import { SimulationSnapshotReportPayload } from '../common/socketPayloads/SimulationSnapshotReportPayload';
 
 class SimulationBridge {
   private readonly simulationMap: { [simulationUid: string]: Simulation } = {};
@@ -88,6 +90,22 @@ class SimulationBridge {
   ) => {
     const ns = this.nsMap[simulationUid];
     ns.emit(socketEvents.simulation.nodeDeleted, body);
+  };
+
+  public readonly handleSimulationRequestSnapshot = (
+    simulationUid: string,
+    body: SimulationRequestSnapshotPayload
+  ) => {
+    const simulation = this.simulationMap[simulationUid];
+    simulation.handleSimulationRequestSnapshot(body);
+  };
+
+  public readonly sendSimulationSnapshotReport = (
+    simulationUid: string,
+    body: SimulationSnapshotReportPayload
+  ): void => {
+    const ns = this.nsMap[simulationUid];
+    ns.emit(socketEvents.simulation.snapshotReport, body);
   };
 }
 

--- a/common/.eslintrc.js
+++ b/common/.eslintrc.js
@@ -30,5 +30,6 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
+    '@typescript-eslint/no-empty-interface': 'off',
   },
 };

--- a/common/src/SimulationNodeSnapshot.ts
+++ b/common/src/SimulationNodeSnapshot.ts
@@ -1,0 +1,5 @@
+export interface SimulationNodeSnapshot {
+  readonly nodeUid: string;
+  readonly positionX: number;
+  readonly positionY: number;
+}

--- a/common/src/SimulationSnapshot.ts
+++ b/common/src/SimulationSnapshot.ts
@@ -1,0 +1,6 @@
+import { SimulationNodeSnapshot } from './SimulationNodeSnapshot';
+
+export interface SimulationSnapshot {
+  readonly simulationUid: string;
+  readonly nodeMap: { [nodeUid: string]: SimulationNodeSnapshot };
+}

--- a/common/src/constants/socketEvents.ts
+++ b/common/src/constants/socketEvents.ts
@@ -11,5 +11,7 @@ export const socketEvents = {
     nodeCreated: 'simulation-node-created',
     deleteNode: 'simulation-delete-node',
     nodeDeleted: 'simulation-node-deleted',
+    requestSnapshot: 'simulation-request-snapshot',
+    snapshotReport: 'simulation-snapshot-report',
   },
 } as const;

--- a/common/src/socketPayloads/SimulationRequestStatePayload.ts
+++ b/common/src/socketPayloads/SimulationRequestStatePayload.ts
@@ -1,0 +1,1 @@
+export interface SimulationRequestSnapshotPayload {}

--- a/common/src/socketPayloads/SimulationSnapshotReportPayload.ts
+++ b/common/src/socketPayloads/SimulationSnapshotReportPayload.ts
@@ -1,0 +1,5 @@
+import { SimulationSnapshot } from '../SimulationSnapshot';
+
+export interface SimulationSnapshotReportPayload {
+  snapshot: SimulationSnapshot;
+}

--- a/frontend/.eslintrc.js
+++ b/frontend/.eslintrc.js
@@ -31,5 +31,6 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
+    '@typescript-eslint/no-empty-interface': 'off',
   },
 };

--- a/frontend/src/components/NodeModal/NodeModal.tsx
+++ b/frontend/src/components/NodeModal/NodeModal.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Col, Container, Modal, Row, Tab, Table, Tabs } from 'react-bootstrap';
 import './NodeModal.css';
-import { SimulationNodePayload } from '../../state/simulation/SimulationNodePayload';
+import { NodeData } from '../../state/simulation/NodeData';
 
 interface NodeModalProps {
   show: boolean;
   closeHandler: () => void;
-  node: SimulationNodePayload;
+  node: NodeData;
 }
 
 const NodeModal: React.FC<NodeModalProps> = (props) => {

--- a/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
+++ b/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
@@ -5,9 +5,9 @@ import { simulationBridge } from '../../services/simulationBridge';
 import { useSelector } from 'react-redux';
 import { RootState } from '../../state/RootState';
 import { ContextMenu, ContextMenuTrigger, MenuItem } from 'react-contextmenu';
-import { SimulationNodePayload } from '../../state/simulation/SimulationNodePayload';
 import NodeModal from '../../components/NodeModal/NodeModal';
 // import nodeIcon from './pcIcon.png';
+import { NodeData } from '../../state/simulation/NodeData';
 
 interface SandboxSimulationParamTypes {
   simulationUid: string;
@@ -23,12 +23,10 @@ const SandboxSimulation: React.FC = () => {
   );
 
   const nodes = useSelector((state: RootState) =>
-    Object.values(state.simulation[simulationUid]?.nodes || {})
+    Object.values(state.simulation[simulationUid]?.nodeMap || {})
   );
 
-  const [viewingNode, setViewingNode] = useState<SimulationNodePayload | null>(
-    null
-  );
+  const [viewingNode, setViewingNode] = useState<NodeData | null>(null);
 
   const connect = useCallback(async () => {
     await simulationBridge.connect(simulationUid);

--- a/frontend/src/services/SimulationSocketListener.ts
+++ b/frontend/src/services/SimulationSocketListener.ts
@@ -5,6 +5,7 @@ import { SimulationNodeCreatedPayload } from '../common/socketPayloads/Simulatio
 import { logSocketReceive } from '../common/utils/socketLogUtils';
 import { socketEvents } from '../common/constants/socketEvents';
 import { SimulationNodeDeletedPayload } from '../common/socketPayloads/SimulationNodeDeletedPayload';
+import { SimulationSnapshotReportPayload } from '../common/socketPayloads/SimulationSnapshotReportPayload';
 
 export class SimulationSocketListener {
   private readonly simulationUid: string;
@@ -21,6 +22,10 @@ export class SimulationSocketListener {
     socket.on(
       socketEvents.simulation.nodeDeleted,
       this.handleSimulationNodeDeleted
+    );
+    socket.on(
+      socketEvents.simulation.snapshotReport,
+      this.handleSimulationSnapshotReport
     );
   }
 
@@ -66,6 +71,17 @@ export class SimulationSocketListener {
   ) => {
     store.dispatch(
       simulationSlice.actions.nodeDeleted({
+        simulationUid: this.simulationUid,
+        ...body,
+      })
+    );
+  };
+
+  private readonly handleSimulationSnapshotReport = (
+    body: SimulationSnapshotReportPayload
+  ) => {
+    store.dispatch(
+      simulationSlice.actions.snapshotReport({
         simulationUid: this.simulationUid,
         ...body,
       })

--- a/frontend/src/state/simulation/NodeData.ts
+++ b/frontend/src/state/simulation/NodeData.ts
@@ -1,5 +1,4 @@
 export interface NodeData {
-  simulationUid: string;
   nodeUid: string;
   positionX: number;
   positionY: number;

--- a/frontend/src/state/simulation/SimulationData.ts
+++ b/frontend/src/state/simulation/SimulationData.ts
@@ -1,7 +1,7 @@
 import { NodeData } from './NodeData';
 
 export interface SimulationData {
-  uid: string;
+  simulationUid: string;
   pongs: Array<{ pingDate: number; pongDate: number }>;
-  nodes: { [nodeUid: string]: NodeData };
+  nodeMap: { [nodeUid: string]: NodeData };
 }

--- a/frontend/src/state/simulation/SimulationNodePayload.ts
+++ b/frontend/src/state/simulation/SimulationNodePayload.ts
@@ -1,4 +1,4 @@
-export interface SimulationNodePayload {
+export interface SimulationNodeCreatedPayload {
   simulationUid: string;
   nodeUid: string;
   positionX: number;

--- a/frontend/src/state/simulation/SimulationSnapshotReportPayload.ts
+++ b/frontend/src/state/simulation/SimulationSnapshotReportPayload.ts
@@ -1,0 +1,6 @@
+import { SimulationSnapshot } from '../../common/SimulationSnapshot';
+
+export interface SimulationSnapshotReportPayload {
+  simulationUid: string;
+  snapshot: SimulationSnapshot;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1797,6 +1797,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.6.tgz#f4c7ec43e81b319a9815115031709f26987891f0"
   integrity sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==
 
+"@types/lodash@^4.14.165":
+  version "4.14.165"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.165.tgz#74d55d947452e2de0742bad65270433b63a8c30f"
+  integrity sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==
+
 "@types/mime@*":
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.3.tgz#c893b73721db73699943bfc3653b1deb7faa4a3a"


### PR DESCRIPTION
Quire tasks:
1. [**27:** Simulation serialization (sandbox)](https://quire.io/w/ctisbtes-main/27)
1. [**50:** Initial simulation state fetch (sandbox)](https://quire.io/w/ctisbtes-main/50)

Changes:
1. Backend: Implemented the snapshot logic on `Simulation` and `SimulationNode` classes.

1. New socket events: `simulation-request-snapshot` and `simulation-snapshot-report`.

1. Frontend emits a `simulation-request-snapshot` after it receives the `simulation-welcome`.

1. Frontend: `simulationBridge.connect(...)` promise resolves after it receives the first `simulation-snapshot-report`, instead of resolving on `simulation-welcome`.

1. Installed `lodash` on backend.