### PR TITLE
Backend Socket Re-architecture

### DIFF
--- a/backend/src/core/simulationBridge.ts
+++ b/backend/src/core/simulationBridge.ts
@@ -50,8 +50,10 @@ class SimulationBridge {
     simulationUid: string,
     body: SimulationPingPayload
   ) => {
-    const simulation = this.simulationMap[simulationUid];
-    simulation.handleSimulationPing(body);
+    this.sendSimulationPong(simulationUid, {
+      pingDate: body.date,
+      pongDate: Date.now(),
+    });
   };
 
   public readonly sendSimulationPong = (
@@ -67,7 +69,9 @@ class SimulationBridge {
     body: SimulationCreateNodePayload
   ) => {
     const simulation = this.simulationMap[simulaitonUid];
-    simulation.handleSimulationCreateNode(body);
+    const newNode = simulation.createNode(body.positionX, body.positionY);
+    const nodeSnapshot = newNode.takeSnapshot();
+    this.sendSimulationNodeCreated(simulaitonUid, nodeSnapshot);
   };
 
   public readonly handleSimulationUpdateNodePosition = (
@@ -75,7 +79,8 @@ class SimulationBridge {
     body: SimulationUpdateNodePositionPayload
   ) => {
     const simulation = this.simulationMap[simulaitonUid];
-    simulation.handleSimulationUpdateNodePosition(body);
+    simulation.updateNodePosition(body.nodeUid, body.positionX, body.positionY);
+    this.sendSimulationNodePositionUpdated(simulaitonUid, body);
   };
 
   public readonly sendSimulationNodeCreated = (
@@ -91,7 +96,8 @@ class SimulationBridge {
     body: SimulationDeleteNodePayload
   ) => {
     const simulation = this.simulationMap[simulationUid];
-    simulation.handleSimulationDeleteNode(body);
+    simulation.deleteNode(body.nodeUid);
+    this.sendSimulationNodeDeleted(simulationUid, { nodeUid: body.nodeUid });
   };
 
   public readonly sendSimulationNodeDeleted = (
@@ -104,10 +110,12 @@ class SimulationBridge {
 
   public readonly handleSimulationRequestSnapshot = (
     simulationUid: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     body: SimulationRequestSnapshotPayload
   ) => {
     const simulation = this.simulationMap[simulationUid];
-    simulation.handleSimulationRequestSnapshot(body);
+    const snapshot = simulation.takeSnapshot();
+    this.sendSimulationSnapshotReport(simulationUid, { snapshot });
   };
 
   public readonly sendSimulationSnapshotReport = (

--- a/backend/src/core/simulationBridge.ts
+++ b/backend/src/core/simulationBridge.ts
@@ -1,18 +1,7 @@
 import { Namespace } from 'socket.io';
 import { Simulation } from './Simulation';
 import { fatalAssert } from '../utils/fatalAssert';
-import { socketEvents } from '../common/constants/socketEvents';
-import { SimulationPongPayload } from '../common/socketPayloads/SimulationPongPayload';
-import { SimulationCreateNodePayload } from '../common/socketPayloads/SimulationCreateNodePayload';
-import { SimulationNodeCreatedPayload } from '../common/socketPayloads/SimulationNodeCreatedPayload';
-import { SimulationPingPayload } from '../common/socketPayloads/SimulationPingPayload';
 import { SimulationNamespaceListener } from './SimulationNamespaceListener';
-import { SimulationDeleteNodePayload } from '../common/socketPayloads/SimulationDeleteNodePayload';
-import { SimulationNodeDeletedPayload } from '../common/socketPayloads/SimulationNodeDeletedPayload';
-import { SimulationRequestSnapshotPayload } from '../common/socketPayloads/SimulationRequestStatePayload';
-import { SimulationSnapshotReportPayload } from '../common/socketPayloads/SimulationSnapshotReportPayload';
-import { SimulationUpdateNodePositionPayload } from '../common/socketPayloads/SimulationUpdateNodePositionPayload';
-import { SimulationNodePositionUpdatedPayload } from '../common/socketPayloads/SimulationNodePositionUpdatedPayload';
 
 class SimulationBridge {
   private readonly simulationMap: { [simulationUid: string]: Simulation } = {};
@@ -27,7 +16,7 @@ class SimulationBridge {
     ns: Namespace
   ) => {
     const newSimulation = new Simulation(simulationUid);
-    const listener = new SimulationNamespaceListener(simulationUid, ns);
+    const listener = new SimulationNamespaceListener(newSimulation, ns);
 
     this.simulationMap[simulationUid] = newSimulation;
     this.nsMap[simulationUid] = ns;
@@ -44,94 +33,6 @@ class SimulationBridge {
     );
 
     return simulationExists;
-  };
-
-  public readonly handleSimulationPing = (
-    simulationUid: string,
-    body: SimulationPingPayload
-  ) => {
-    this.sendSimulationPong(simulationUid, {
-      pingDate: body.date,
-      pongDate: Date.now(),
-    });
-  };
-
-  public readonly sendSimulationPong = (
-    simulationUid: string,
-    body: SimulationPongPayload
-  ) => {
-    const ns = this.nsMap[simulationUid];
-    ns.emit(socketEvents.simulation.pong, body);
-  };
-
-  public readonly handleSimulationCreateNode = (
-    simulaitonUid: string,
-    body: SimulationCreateNodePayload
-  ) => {
-    const simulation = this.simulationMap[simulaitonUid];
-    const newNode = simulation.createNode(body.positionX, body.positionY);
-    const nodeSnapshot = newNode.takeSnapshot();
-    this.sendSimulationNodeCreated(simulaitonUid, nodeSnapshot);
-  };
-
-  public readonly handleSimulationUpdateNodePosition = (
-    simulaitonUid: string,
-    body: SimulationUpdateNodePositionPayload
-  ) => {
-    const simulation = this.simulationMap[simulaitonUid];
-    simulation.updateNodePosition(body.nodeUid, body.positionX, body.positionY);
-    this.sendSimulationNodePositionUpdated(simulaitonUid, body);
-  };
-
-  public readonly sendSimulationNodeCreated = (
-    simulationUid: string,
-    body: SimulationNodeCreatedPayload
-  ) => {
-    const ns = this.nsMap[simulationUid];
-    ns.emit(socketEvents.simulation.nodeCreated, body);
-  };
-
-  public readonly handleSimulationDeleteNode = (
-    simulationUid: string,
-    body: SimulationDeleteNodePayload
-  ) => {
-    const simulation = this.simulationMap[simulationUid];
-    simulation.deleteNode(body.nodeUid);
-    this.sendSimulationNodeDeleted(simulationUid, { nodeUid: body.nodeUid });
-  };
-
-  public readonly sendSimulationNodeDeleted = (
-    simulationUid: string,
-    body: SimulationNodeDeletedPayload
-  ) => {
-    const ns = this.nsMap[simulationUid];
-    ns.emit(socketEvents.simulation.nodeDeleted, body);
-  };
-
-  public readonly handleSimulationRequestSnapshot = (
-    simulationUid: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    body: SimulationRequestSnapshotPayload
-  ) => {
-    const simulation = this.simulationMap[simulationUid];
-    const snapshot = simulation.takeSnapshot();
-    this.sendSimulationSnapshotReport(simulationUid, { snapshot });
-  };
-
-  public readonly sendSimulationSnapshotReport = (
-    simulationUid: string,
-    body: SimulationSnapshotReportPayload
-  ): void => {
-    const ns = this.nsMap[simulationUid];
-    ns.emit(socketEvents.simulation.snapshotReport, body);
-  };
-
-  public readonly sendSimulationNodePositionUpdated = (
-    simulationUid: string,
-    body: SimulationNodePositionUpdatedPayload
-  ) => {
-    const ns = this.nsMap[simulationUid];
-    ns.emit(socketEvents.simulation.nodePositionUpdated, body);
   };
 }
 

--- a/backend/src/core/simulationManager.ts
+++ b/backend/src/core/simulationManager.ts
@@ -3,7 +3,7 @@ import { Simulation } from './Simulation';
 import { fatalAssert } from '../utils/fatalAssert';
 import { SimulationNamespaceListener } from './SimulationNamespaceListener';
 
-class SimulationBridge {
+class SimulationManager {
   private readonly simulationMap: { [simulationUid: string]: Simulation } = {};
   private readonly nsMap: { [simulationUid: string]: Namespace } = {};
 
@@ -11,10 +11,7 @@ class SimulationBridge {
     [simulaitonUid: string]: SimulationNamespaceListener;
   } = {};
 
-  public readonly setupNewSimulation = (
-    simulationUid: string,
-    ns: Namespace
-  ) => {
+  public readonly createSimulation = (simulationUid: string, ns: Namespace) => {
     const newSimulation = new Simulation(simulationUid);
     const listener = new SimulationNamespaceListener(newSimulation, ns);
 
@@ -36,4 +33,4 @@ class SimulationBridge {
   };
 }
 
-export const simulationBridge = new SimulationBridge();
+export const simulationManager = new SimulationManager();

--- a/backend/src/restControllers/simulationInstanceBroker/simulationInstanceBrokerController.ts
+++ b/backend/src/restControllers/simulationInstanceBroker/simulationInstanceBrokerController.ts
@@ -1,5 +1,5 @@
 import { Controller, Get, Query, Route } from 'tsoa';
-import { simulationBridge } from '../../core/simulationBridge';
+import { simulationManager } from '../../core/simulationManager';
 import { socketManager } from '../../socketManager';
 import { simulationUidGenerator } from '../../utils/uidGenerators';
 
@@ -13,14 +13,14 @@ export class SimulationInstanceBrokerController extends Controller {
   public async create(): Promise<string> {
     const uidStr = simulationUidGenerator.next().toString();
 
-    if (simulationBridge.checkSimulationExists(uidStr)) {
+    if (simulationManager.checkSimulationExists(uidStr)) {
       throw new Error(
         `A simulation with ID ${uidStr} already exists! Refusing to create.`
       );
     }
 
     const ns = socketManager.getOrCreateNamespace(uidStr);
-    simulationBridge.setupNewSimulation(uidStr, ns);
+    simulationManager.createSimulation(uidStr, ns);
 
     console.log(
       `created simulation instance with uid: ${uidStr} name: ${ns.name}`
@@ -34,6 +34,6 @@ export class SimulationInstanceBrokerController extends Controller {
    */
   @Get('check')
   public async check(@Query() simulationUid: string): Promise<boolean> {
-    return simulationBridge.checkSimulationExists(simulationUid);
+    return simulationManager.checkSimulationExists(simulationUid);
   }
 }


### PR DESCRIPTION
1. Simplified listeners and emitters, they are no longer repated in multiple places, all listeners and emitters are only in the SimulationNamespaceListener class.

1. Simulation class no longer knows anything about sockets.

1. SimulationBridge is now SimulationManager, because it no longer is a bridge between sockets and simulations.

1. SimulationManager also doesn't deal with socket events any more. SimulationNamespaceListener directly calls on Simulation without going through a bridge.