### PR TITLE
Undo Redo (Frontend)

### DIFF
--- a/backend/src/core/commands/SimulationCreateNodeCommand.ts
+++ b/backend/src/core/commands/SimulationCreateNodeCommand.ts
@@ -1,0 +1,54 @@
+import { SimulationCreateNodePayload } from '../../common/socketPayloads/SimulationCreateNodePayload';
+import { Simulation } from '../Simulation';
+import { SimulationNamespaceListener } from '../SimulationNamespaceListener';
+import { UndoubleAction } from '../undoRedo/UndoubleAction';
+import { SimulationNodeSnapshot } from '../../common/SimulationNodeSnapshot';
+
+export class SimulationCreateNodeCommand implements UndoubleAction {
+  private readonly simulation: Simulation;
+  private readonly socketEventEmitter: SimulationNamespaceListener;
+  private readonly eventPayload: SimulationCreateNodePayload;
+
+  private createdNodeUid: string | undefined;
+  private createdNodeSnapshot: SimulationNodeSnapshot | undefined;
+
+  constructor(
+    simulation: Simulation,
+    socketEventEmitter: SimulationNamespaceListener,
+    eventPayload: SimulationCreateNodePayload
+  ) {
+    this.simulation = simulation;
+    this.socketEventEmitter = socketEventEmitter;
+    this.eventPayload = eventPayload;
+  }
+
+  public readonly execute = (): void => {
+    const newNode = this.simulation.createNode(
+      this.eventPayload.positionX,
+      this.eventPayload.positionY
+    );
+    this.createdNodeUid = newNode.nodeUid;
+    this.createdNodeSnapshot = newNode.takeSnapshot();
+    this.socketEventEmitter.sendSimulationNodeCreated(this.createdNodeSnapshot);
+  };
+
+  public readonly redo = (): void => {
+    if (undefined === this.createdNodeSnapshot) {
+      throw new Error('redo invoked before execute!');
+    }
+
+    this.simulation.createNodeWithSnapshot(this.createdNodeSnapshot);
+    this.socketEventEmitter.sendSimulationNodeCreated(this.createdNodeSnapshot);
+  };
+
+  public readonly undo = (): void => {
+    if (undefined === this.createdNodeUid) {
+      throw new Error('undo invoked before execute!');
+    }
+
+    this.simulation.deleteNode(this.createdNodeUid);
+    this.socketEventEmitter.sendSimulationNodeDeleted({
+      nodeUid: this.createdNodeUid,
+    });
+  };
+}

--- a/backend/src/core/commands/SimulationDeleteNodeCommand.ts
+++ b/backend/src/core/commands/SimulationDeleteNodeCommand.ts
@@ -1,0 +1,49 @@
+import { SimulationNodeSnapshot } from '../../common/SimulationNodeSnapshot';
+import { SimulationDeleteNodePayload } from '../../common/socketPayloads/SimulationDeleteNodePayload';
+import { Simulation } from '../Simulation';
+import { SimulationNamespaceListener } from '../SimulationNamespaceListener';
+import { UndoubleAction } from '../undoRedo/UndoubleAction';
+
+export class SimulationDeleteNodeCommand implements UndoubleAction {
+  private readonly simulation: Simulation;
+  private readonly socketEventEmitter: SimulationNamespaceListener;
+  private readonly eventPayload: SimulationDeleteNodePayload;
+
+  private createdNodeSnapshot: SimulationNodeSnapshot | undefined;
+
+  constructor(
+    simulation: Simulation,
+    socketEventEmitter: SimulationNamespaceListener,
+    eventPayload: SimulationDeleteNodePayload
+  ) {
+    this.simulation = simulation;
+    this.socketEventEmitter = socketEventEmitter;
+    this.eventPayload = eventPayload;
+  }
+
+  private readonly perform = (): void => {
+    this.simulation.deleteNode(this.eventPayload.nodeUid);
+    this.socketEventEmitter.sendSimulationNodeDeleted({
+      nodeUid: this.eventPayload.nodeUid,
+    });
+  };
+
+  public readonly execute = (): void => {
+    this.createdNodeSnapshot = this.simulation.nodeMap[
+      this.eventPayload.nodeUid
+    ].takeSnapshot();
+
+    this.perform();
+  };
+
+  public readonly redo = this.perform;
+
+  public readonly undo = (): void => {
+    if (undefined === this.createdNodeSnapshot) {
+      throw new Error('undo invoked before execute!');
+    }
+
+    this.simulation.createNodeWithSnapshot(this.createdNodeSnapshot);
+    this.socketEventEmitter.sendSimulationNodeCreated(this.createdNodeSnapshot);
+  };
+}

--- a/backend/src/core/commands/SimulationUpdateNodePositionCommand.ts
+++ b/backend/src/core/commands/SimulationUpdateNodePositionCommand.ts
@@ -1,0 +1,65 @@
+import { SimulationUpdateNodePositionPayload } from '../../common/socketPayloads/SimulationUpdateNodePositionPayload';
+import { Simulation } from '../Simulation';
+import { SimulationNamespaceListener } from '../SimulationNamespaceListener';
+import { UndoubleAction } from '../undoRedo/UndoubleAction';
+
+export class SimulationUpdateNodePositionCommand implements UndoubleAction {
+  private readonly simulation: Simulation;
+  private readonly socketEventEmitter: SimulationNamespaceListener;
+  private readonly eventPayload: SimulationUpdateNodePositionPayload;
+
+  private previousPositionX: number | undefined;
+  private previousPositionY: number | undefined;
+
+  constructor(
+    simulation: Simulation,
+    socketEventEmitter: SimulationNamespaceListener,
+    eventPayload: SimulationUpdateNodePositionPayload
+  ) {
+    this.simulation = simulation;
+    this.socketEventEmitter = socketEventEmitter;
+    this.eventPayload = eventPayload;
+  }
+
+  private readonly perform = (): void => {
+    this.simulation.updateNodePosition(
+      this.eventPayload.nodeUid,
+      this.eventPayload.positionX,
+      this.eventPayload.positionY
+    );
+    this.socketEventEmitter.sendSimulationNodePositionUpdated(
+      this.eventPayload
+    );
+  };
+
+  public readonly execute = (): void => {
+    const node = this.simulation.nodeMap[this.eventPayload.nodeUid];
+    this.previousPositionX = node.positionX;
+    this.previousPositionY = node.positionY;
+
+    this.perform();
+  };
+
+  public readonly redo = this.perform;
+
+  public readonly undo = (): void => {
+    if (
+      undefined === this.previousPositionX ||
+      undefined === this.previousPositionY
+    ) {
+      throw new Error('undo invoked before execute!');
+    }
+
+    this.simulation.updateNodePosition(
+      this.eventPayload.nodeUid,
+      this.previousPositionX,
+      this.previousPositionY
+    );
+
+    this.socketEventEmitter.sendSimulationNodePositionUpdated({
+      nodeUid: this.eventPayload.nodeUid,
+      positionX: this.previousPositionX,
+      positionY: this.previousPositionY,
+    });
+  };
+}

--- a/backend/src/core/undoRedo/ActionHistoryKeeper.ts
+++ b/backend/src/core/undoRedo/ActionHistoryKeeper.ts
@@ -4,10 +4,13 @@ export class ActionHistoryKeeper {
   private undoStack: UndoubleAction[] = [];
   private redoStack: UndoubleAction[] = [];
 
-  public registerAndExecute(action: UndoubleAction): void {
+  /**
+   * This method only registers the enevt to the undo stack.
+   * You must perform the first execution on the caller site!
+   */
+  public register(action: UndoubleAction): void {
     this.undoStack.push(action);
     this.redoStack = [];
-    action.execute();
   }
 
   public undo(): void {
@@ -21,7 +24,7 @@ export class ActionHistoryKeeper {
   public redo(): void {
     const toRedo = this.redoStack.pop();
     if (toRedo) {
-      toRedo.execute();
+      toRedo.redo();
       this.undoStack.push(toRedo);
     }
   }

--- a/backend/src/core/undoRedo/UndoubleAction.ts
+++ b/backend/src/core/undoRedo/UndoubleAction.ts
@@ -1,4 +1,10 @@
 export interface UndoubleAction {
+  /** Perform the action for the first time. */
   execute(): void;
+
+  /** Perform the action again after an undo. */
+  redo(): void;
+
+  /** Revert the action. */
   undo(): void;
 }

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -6,7 +6,7 @@ import './Navbar.scss';
 const Navbar: React.FC = () => {
   return (
     <div className="comp-navbar">
-      <nav className="navbar navbar-expand-lg navbar-light bg-light">
+      <nav className="navbar navbar-expand-lg navbar-light bg-light border-bottom">
         <Link to="/" className="navbar-brand">
           BTES
         </Link>

--- a/frontend/src/pages/SandboxSimulation/SandboxSimulation.scss
+++ b/frontend/src/pages/SandboxSimulation/SandboxSimulation.scss
@@ -4,10 +4,20 @@
   height: 100%;
   overflow: hidden;
 
-  &--board-container {
+  &--body {
     display: flex;
+    flex-direction: column;
     width: 100%;
     height: 100%;
+  }
+
+  &--toolbox {
+    flex: 0 0 content;
+  }
+
+  &--board-container {
+    display: flex;
+    flex: 1 1;
     overflow: auto;
   }
 

--- a/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
+++ b/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
@@ -77,13 +77,42 @@ const SandboxSimulation: React.FC = () => {
     showBoardContextMenu(event);
   };
 
+  const handleUndo = useCallback(() => {
+    simulationBridge.sendSimulationUndo(simulationUid);
+  }, [simulationUid]);
+
+  const handleRedo = useCallback(() => {
+    simulationBridge.sendSimulationRedo(simulationUid);
+  }, [simulationUid]);
+
+  const handleKeyUp = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.ctrlKey && event.key === 'z') {
+        handleUndo();
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return false;
+      }
+
+      if (event.ctrlKey && event.key === 'y') {
+        handleRedo();
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return false;
+      }
+    },
+    [handleRedo, handleUndo]
+  );
+
   useEffect(() => {
+    document.addEventListener('keyup', handleKeyUp);
     connect();
 
     return () => {
+      document.removeEventListener('keyup', handleKeyUp);
       teardown();
     };
-  }, [connect, teardown]);
+  }, [connect, handleKeyUp, teardown]);
 
   return (
     <div className="page-sandbox-simulation">

--- a/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
+++ b/frontend/src/pages/SandboxSimulation/SandboxSimulation.tsx
@@ -1,9 +1,13 @@
 import { useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
 import React, { useCallback, useEffect, useState } from 'react';
-import { Card } from 'react-bootstrap';
+import { Button, ButtonGroup, ButtonToolbar, Card } from 'react-bootstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faNetworkWired } from '@fortawesome/free-solid-svg-icons';
+import {
+  faNetworkWired,
+  faRedo,
+  faUndo,
+} from '@fortawesome/free-solid-svg-icons';
 import {
   animation,
   Item,
@@ -118,19 +122,43 @@ const SandboxSimulation: React.FC = () => {
     <div className="page-sandbox-simulation">
       {connected ? (
         <>
-          <div className="page-sandbox-simulation--board-container">
-            <div
-              className="page-sandbox-simulation--board"
-              onContextMenu={onBoardContextMenu}
-            >
-              {nodes.map((node) => (
-                <SimulationNode
-                  key={node.nodeUid}
-                  simulationUid={simulationUid}
-                  data={node}
-                  launchHandler={(nodeUid) => setViewingNodeUid(nodeUid)}
-                ></SimulationNode>
-              ))}
+          <div className="page-sandbox-simulation--body">
+            <div className="page-sandbox-simulation--toolbox bg-light border-bottom pl-2">
+              <ButtonToolbar>
+                <ButtonGroup className="mr-2">
+                  <Button
+                    onClick={handleUndo}
+                    variant="light"
+                    className="rounded-0"
+                    title="Undo"
+                  >
+                    <FontAwesomeIcon icon={faUndo} />
+                  </Button>
+                  <Button
+                    onClick={handleRedo}
+                    variant="light"
+                    className="rounded-0"
+                    title="Redo"
+                  >
+                    <FontAwesomeIcon icon={faRedo} />
+                  </Button>
+                </ButtonGroup>
+              </ButtonToolbar>
+            </div>
+            <div className="page-sandbox-simulation--board-container">
+              <div
+                className="page-sandbox-simulation--board"
+                onContextMenu={onBoardContextMenu}
+              >
+                {nodes.map((node) => (
+                  <SimulationNode
+                    key={node.nodeUid}
+                    simulationUid={simulationUid}
+                    data={node}
+                    launchHandler={(nodeUid) => setViewingNodeUid(nodeUid)}
+                  ></SimulationNode>
+                ))}
+              </div>
             </div>
           </div>
           <Menu

--- a/frontend/src/services/simulationBridge.ts
+++ b/frontend/src/services/simulationBridge.ts
@@ -130,6 +130,14 @@ class SimulationBridge {
     this.emit(simulationUid, socketEvents.simulation.updateNodePosition, body);
   }
 
+  public sendSimulationUndo(simulationUid: string) {
+    this.emit(simulationUid, socketEvents.simulation.undo, null);
+  }
+
+  public sendSimulationRedo(simulationUid: string) {
+    this.emit(simulationUid, socketEvents.simulation.redo, null);
+  }
+
   private setupNewConnection(simulationUid: string, socket: Socket) {
     store.dispatch(simulationSlice.actions.setup({ simulationUid }));
     this.uidtoSocketMap[simulationUid] = socket;


### PR DESCRIPTION
Quire: 
Main task: [#62 Undo-Redo (frontend)](https://quire.io/w/ctisbtes-main/62/Undo-Redo_(frontend))
Also changes for: [#63 Undo-Redo (backend)](https://quire.io/w/ctisbtes-main/63/Undo-Redo_(backend))

Frontend:
1. Added a toolbar to the top of `SandboxSimulation` with Undo and Redo buttons.
1. Added a keyboard event handler in `SandboxSimulation` for `CTRL+Z` for undo and `CTRL+Y` for redo.
1. Implemented undo/redo socket infrastructure.

Backend:
1. Converted all `UndoableAction`s to Command pattern, with their own separate classes.

