### PR TITLE
Connection latency adjustment (services and state only, no visuals)

### DIFF
--- a/backend/src/core/SimulationNamespaceEmitter.ts
+++ b/backend/src/core/SimulationNamespaceEmitter.ts
@@ -10,6 +10,7 @@ import { SimulationNodeMailReceivedPayload } from '../common/socketPayloads/Simu
 import { SimulationNodesConnectedPayload } from '../common/socketPayloads/SimulationNodesConnectedPayload';
 import { SimulationNodesDisconnectedPayload } from '../common/socketPayloads/SimulationNodesDisconnectedPayload';
 import { SimulationTimeScaleChangedPayload } from '../common/socketPayloads/SimulationTimeScaleChangedPayload';
+import { SimulationConnectionLatencyChangedPayload } from '../common/socketPayloads/SimulationConnectionLatencyChangedPayload';
 
 export class SimulationNamespaceEmitter {
   private readonly ns: Namespace;
@@ -76,5 +77,11 @@ export class SimulationNamespaceEmitter {
     body: SimulationTimeScaleChangedPayload
   ): void => {
     this.ns.emit(socketEvents.simulation.timeScaleChanged, body);
+  };
+
+  public readonly sendSimulationConnectionLatencyChanged = (
+    body: SimulationConnectionLatencyChangedPayload
+  ): void => {
+    this.ns.emit(socketEvents.simulation.connectionLatencyChanged, body);
   };
 }

--- a/backend/src/core/SimulationNamespaceListener.ts
+++ b/backend/src/core/SimulationNamespaceListener.ts
@@ -25,6 +25,8 @@ import { SimulationNamespaceEmitter } from './SimulationNamespaceEmitter';
 import { NodeConnectionMap } from './network/NodeConnectionMap';
 import { ControlledTimerService } from './network/ControlledTimerService';
 import { SimulationChangeTimeScalePayload } from '../common/socketPayloads/SimulationChangeTimeScalePayload';
+import { SimulationConnectionChangeLatencyPayload } from '../common/socketPayloads/SimulationConnectionChangeLatencyPayload';
+import { SimulationConnectionChangeLatencyCommand } from './commands/SimulationConnectionChangeLatencyCommand';
 
 export class SimulationNamespaceListener {
   private readonly simulation: Simulation;
@@ -107,6 +109,10 @@ export class SimulationNamespaceListener {
     socket.on(
       socketEvents.simulation.changeTimeScale,
       this.handleSimulationChangeTimeScale
+    );
+    socket.on(
+      socketEvents.simulation.connectionChangeLatency,
+      this.handleConnectionChangeLatency
     );
   };
 
@@ -242,5 +248,17 @@ export class SimulationNamespaceListener {
     body: SimulationChangeTimeScalePayload
   ) => {
     this.timerService.setTimeScale(body.timeScale);
+  };
+
+  private readonly handleConnectionChangeLatency = (
+    body: SimulationConnectionChangeLatencyPayload
+  ) => {
+    const command = new SimulationConnectionChangeLatencyCommand(
+      this.connectionMap,
+      body
+    );
+
+    this.commandHistoryManager.register(command);
+    command.execute();
   };
 }

--- a/backend/src/core/commands/SimulationConnectionChangeLatencyCommand.ts
+++ b/backend/src/core/commands/SimulationConnectionChangeLatencyCommand.ts
@@ -1,0 +1,45 @@
+import { UndoableSimulationCommand } from '../undoRedo/UndoableSimulationCommand';
+import { SimulationConnectionChangeLatencyPayload } from '../../common/socketPayloads/SimulationConnectionChangeLatencyPayload';
+import { NodeConnectionMap } from '../network/NodeConnectionMap';
+
+export class SimulationConnectionChangeLatencyCommand
+  implements UndoableSimulationCommand {
+  private readonly connectionMap: NodeConnectionMap;
+  private readonly eventPayload: SimulationConnectionChangeLatencyPayload;
+
+  private previousLatency: number | null = null;
+
+  private get connection() {
+    return this.connectionMap.getWithAssert(
+      this.eventPayload.firstNodeUid,
+      this.eventPayload.secondNodeUid
+    );
+  }
+
+  constructor(
+    connectionMap: NodeConnectionMap,
+    eventPayload: SimulationConnectionChangeLatencyPayload
+  ) {
+    this.connectionMap = connectionMap;
+    this.eventPayload = eventPayload;
+  }
+
+  private readonly perform = (): void => {
+    this.connection.setLatencyInMs(this.eventPayload.latencyInMs);
+  };
+
+  public readonly execute = (): void => {
+    this.previousLatency = this.connection.latencyInMs;
+    this.perform();
+  };
+
+  public readonly redo = this.perform;
+
+  public readonly undo = (): void => {
+    if (null === this.previousLatency) {
+      throw new Error('undo called before execute!');
+    }
+
+    this.connection.setLatencyInMs(this.previousLatency);
+  };
+}

--- a/backend/src/core/network/NodeConnection.ts
+++ b/backend/src/core/network/NodeConnection.ts
@@ -1,7 +1,10 @@
 import { SimulationNode } from '../SimulationNode';
 import { NodeConnectionSnapshot } from '../../common/NodeConnectionSnapshot';
+import { SimulationNamespaceEmitter } from '../SimulationNamespaceEmitter';
 
 export class NodeConnection {
+  private readonly socketEmitter: SimulationNamespaceEmitter;
+
   public readonly firstNode: SimulationNode;
   public readonly secondNode: SimulationNode;
 
@@ -11,10 +14,12 @@ export class NodeConnection {
   }
 
   constructor(
+    socketEmitter: SimulationNamespaceEmitter,
     firstNode: SimulationNode,
     secondNode: SimulationNode,
     latencyInMs: number
   ) {
+    this.socketEmitter = socketEmitter;
     this.firstNode = firstNode;
     this.secondNode = secondNode;
     this._latencyInMs = latencyInMs;
@@ -22,6 +27,12 @@ export class NodeConnection {
 
   public readonly setLatencyInMs = (ms: number): void => {
     this._latencyInMs = ms;
+
+    this.socketEmitter.sendSimulationConnectionLatencyChanged({
+      firstNodeUid: this.firstNode.nodeUid,
+      secondNodeUid: this.secondNode.nodeUid,
+      latencyInMs: this._latencyInMs,
+    });
   };
 
   public getOtherNode = (nodeUid: string): SimulationNode =>

--- a/backend/src/core/network/NodeConnectionMap.ts
+++ b/backend/src/core/network/NodeConnectionMap.ts
@@ -67,7 +67,13 @@ export class NodeConnectionMap {
     secondNode: SimulationNode,
     latencyInMs = 10
   ): void => {
-    const newConn = new NodeConnection(firstNode, secondNode, latencyInMs);
+    const newConn = new NodeConnection(
+      this.socketEmitter,
+      firstNode,
+      secondNode,
+      latencyInMs
+    );
+
     this.add(newConn);
   };
 

--- a/common/src/constants/socketEvents.ts
+++ b/common/src/constants/socketEvents.ts
@@ -30,5 +30,7 @@ export const socketEvents = {
     resumed: 'simulation-resumed',
     changeTimeScale: 'simulation-change-time-scale',
     timeScaleChanged: 'simulation-time-scale-changed',
+    connectionChangeLatency: 'simulation-connection-change-latency',
+    connectionLatencyChanged: 'simulation-connection-latency-changed',
   },
 } as const;

--- a/common/src/socketPayloads/SimulationConnectionChangeLatencyPayload.ts
+++ b/common/src/socketPayloads/SimulationConnectionChangeLatencyPayload.ts
@@ -1,0 +1,5 @@
+export interface SimulationConnectionChangeLatencyPayload {
+  firstNodeUid: string;
+  secondNodeUid: string;
+  latencyInMs: number;
+}

--- a/common/src/socketPayloads/SimulationConnectionLatencyChangedPayload.ts
+++ b/common/src/socketPayloads/SimulationConnectionLatencyChangedPayload.ts
@@ -1,0 +1,5 @@
+export interface SimulationConnectionLatencyChangedPayload {
+  firstNodeUid: string;
+  secondNodeUid: string;
+  latencyInMs: number;
+}

--- a/frontend/src/services/SimulationSocketListener.ts
+++ b/frontend/src/services/SimulationSocketListener.ts
@@ -13,6 +13,7 @@ import { SimulationNodesConnectedPayload } from '../common/socketPayloads/Simula
 import { SimulationNodesDisconnectedPayload } from '../common/socketPayloads/SimulationNodesDisconnectedPayload';
 import { SimulationNodeMailReceivedPayload } from '../common/socketPayloads/SimulationNodeMailReceivedPayload';
 import { SimulationTimeScaleChangedPayload } from '../common/socketPayloads/SimulationTimeScaleChangedPayload';
+import { SimulationConnectionLatencyChangedPayload } from '../common/socketPayloads/SimulationConnectionLatencyChangedPayload';
 
 export class SimulationSocketListener {
   private readonly simulationUid: string;
@@ -55,6 +56,10 @@ export class SimulationSocketListener {
     socket.on(
       socketEvents.simulation.timeScaleChanged,
       this.handleSimulationTimeScaleChanged
+    );
+    socket.on(
+      socketEvents.simulation.connectionLatencyChanged,
+      this.handleConnectionLatencyChanged
     );
 
     socket.onAny(this.handleAny);
@@ -248,6 +253,17 @@ export class SimulationSocketListener {
   ) => {
     store.dispatch(
       simulationSlice.actions.timeScaleChanged({
+        simulationUid: this.simulationUid,
+        ...body,
+      })
+    );
+  };
+
+  private readonly handleConnectionLatencyChanged = (
+    body: SimulationConnectionLatencyChangedPayload
+  ) => {
+    store.dispatch(
+      simulationSlice.actions.connectionLatencyChanged({
         simulationUid: this.simulationUid,
         ...body,
       })

--- a/frontend/src/services/simulationBridge.ts
+++ b/frontend/src/services/simulationBridge.ts
@@ -19,6 +19,7 @@ import { SimulationDisconnectNodesPayload } from '../common/socketPayloads/Simul
 import { SimulationNodeBroadcastMailPayload } from '../common/socketPayloads/SimulationNodeBroadcastMailPayload';
 import { SimulationNodeUnicastMailPayload } from '../common/socketPayloads/SimulationNodeUnicastMailPayload';
 import { SimulationChangeTimeScalePayload } from '../common/socketPayloads/SimulationChangeTimeScalePayload';
+import { SimulationConnectionChangeLatencyPayload } from '../common/socketPayloads/SimulationConnectionChangeLatencyPayload';
 
 class SimulationBridge {
   private readonly uidtoSocketMap: {
@@ -184,6 +185,17 @@ class SimulationBridge {
 
   public sendSimulationResume(simulationUid: string) {
     this.emit(simulationUid, socketEvents.simulation.resume, null);
+  }
+
+  public sendSimulationConnectionChangeLatency(
+    simulationUid: string,
+    body: SimulationConnectionChangeLatencyPayload
+  ) {
+    this.emit(
+      simulationUid,
+      socketEvents.simulation.connectionChangeLatency,
+      body
+    );
   }
 
   private setupNewConnection(simulationUid: string, socket: Socket) {

--- a/frontend/src/state/simulation/actionPayloads/SimulationConnectionLatencyChangedActionPayload.ts
+++ b/frontend/src/state/simulation/actionPayloads/SimulationConnectionLatencyChangedActionPayload.ts
@@ -1,0 +1,6 @@
+export interface SimulationConnectionLatencyChangedActionPayload {
+  simulationUid: string;
+  firstNodeUid: string;
+  secondNodeUid: string;
+  latencyInMs: number;
+}


### PR DESCRIPTION
Quire: https://quire.io/w/ctisbtes-main/89/Adjustable_connection_latency_(services_only)

Implemented the services and the state required for changing the latency of a `NodeConnection`.

---

Frontend service point for changing the latency of a connection:

```ts
simulationBridge.sendSimulationConnectionChangeLatency(
  simulationUid: string, 
  body: SimulationConnectionChangeLatencyPayload
)
```