### PR TITLE
Undo/Redo backend crash bugfix

### DIFF
--- a/backend/src/core/blockchain/NodeBlockchainApp.ts
+++ b/backend/src/core/blockchain/NodeBlockchainApp.ts
@@ -54,8 +54,6 @@ export class NodeBlockchainApp {
       wallet,
       commonChecker
     );
-
-    this.registerGenesisBlock();
   }
 
   public readonly takeSnapshot = (): NodeBlockchainAppSnapshot => {
@@ -132,12 +130,5 @@ export class NodeBlockchainApp {
       const txHash = hashTx(tx);
       this.txDb.popOrphansWithTxAsInput(txHash).forEach(this.receiveTx);
     }
-  };
-
-  private readonly registerGenesisBlock = (): void => {
-    // TODO: generating the genesis block can be done at the very beginning of the simulation.
-    // that way we can simply reuse it instead of generating it every time.
-    const genesisBlock = makeGenesisBlock();
-    this.blockDb.addGenesis(genesisBlock);
   };
 }

--- a/backend/src/core/blockchain/modules/BlockchainBlockDb.ts
+++ b/backend/src/core/blockchain/modules/BlockchainBlockDb.ts
@@ -12,6 +12,7 @@ import { hasValue } from '../../../common/utils/hasValue';
 import { hashTx } from '../../../common/blockchain/utils/hashTx';
 import { hashBlock } from '../../../common/blockchain/utils/hashBlock';
 import { SimulationNamespaceEmitter } from '../../SimulationNamespaceEmitter';
+import { makeGenesisBlock } from '../utils/makeGenesisBlock';
 
 export type BlockSearchResult =
   | { foundIn: 'blockchain'; result: TreeNode<BlockchainBlock> }
@@ -34,6 +35,11 @@ export class BlockchainBlockDb {
     this.nodeUid = nodeUid;
     this.blockchain = blocks;
     this.orphanage = orphanBlocks;
+
+    if (!hasValue(blocks.root)) {
+      // if we don't have a root, the tree is empty. so register the genesis block.
+      this.addGenesis();
+    }
   }
 
   public readonly takeSnapshot = (): BlockchainBlockDbSnapshot => {
@@ -200,7 +206,12 @@ export class BlockchainBlockDb {
   };
 
   /** Adds the genesis block. */
-  public readonly addGenesis = (genesisBlock: BlockchainBlock): void => {
+  private readonly addGenesis = (): void => {
+    // TODO: generating the genesis block can be done at the very beginning of the simulation.
+    // that way we can simply reuse it instead of generating it every time. That way we can also
+    // parameterize it at the beginning of the simulation.
+    const genesisBlock = makeGenesisBlock();
+
     const id = hashBlock(genesisBlock.header);
     this.blockchain.createNode(id, genesisBlock, null);
 


### PR DESCRIPTION
Fixed the bug that caused a backend crash during undo/redo.

The reason for the crash was a forgotten check to see if the blockchain already had nodes in it. Since the genesis block has no parent, it was hitting a sanity throw in Tree class. Now we only register the genesis block if the node has no blocks in the blockchain -- which means it is being created from scratch and not from a snapshot.